### PR TITLE
Update vlan_vid match according to Table 12 in 1.3 spec 

### DIFF
--- a/oflib/ofl-structs-print.c
+++ b/oflib/ofl-structs-print.c
@@ -172,11 +172,13 @@ print_oxm_tlv(FILE *stream, struct ofl_match_tlv *f, size_t *size){
                                 fprintf(stream, ", ");
                 }
                 else if (field == OFPXMT_OFB_VLAN_VID){
-                            if ((uint16_t) *f->value == OFPVID_NONE)
+                			uint16_t *v = (uint16_t *) f->value;
+                			if (*v == OFPVID_NONE)
                                 fprintf(stream, "vlan_vid= none");
-                            else if ((uint16_t) *f->value == OFPVID_PRESENT)
-                                fprintf(stream, "vlan_vid= present");
-                            else fprintf(stream, "vlan_vid=\"%d\"",*((uint16_t*) f->value));
+                            else if (*v == OFPVID_PRESENT && OXM_HASMASK(f->header))
+                                fprintf(stream, "vlan_vid= any");
+                            else
+                            	fprintf(stream, "vlan_vid=\"%d\"",*v & VLAN_VID_MASK);
                             *size -= 6;                                
                             if (*size > 4)                                
                                 fprintf(stream, ", ");

--- a/oflib/oxm-match.c
+++ b/oflib/oxm-match.c
@@ -259,7 +259,7 @@ parse_oxm_entry(struct ofl_match *match, const struct oxm_field *f,
         /* 802.1Q header. */
         case OFI_OXM_OF_VLAN_VID:{
             uint16_t* vlan_id = (uint16_t*) value;
-            if (ntohs(*vlan_id)> 4095){
+            if (ntohs(*vlan_id)> OFPVID_PRESENT+VLAN_VID_MAX){
                 return ofp_mkerr(OFPET_BAD_MATCH, OFPBMC_BAD_VALUE);
             }
             else
@@ -269,10 +269,11 @@ parse_oxm_entry(struct ofl_match *match, const struct oxm_field *f,
 
         case OFI_OXM_OF_VLAN_VID_W:{
             uint16_t* vlan_id = (uint16_t*) value;
-            uint16_t* vlan_mask = (uint16_t*) value;
-            if (ntohs(*vlan_id) > 4095)
+            uint16_t* vlan_mask = (uint16_t*) mask;
+
+            if (ntohs(*vlan_id) > OFPVID_PRESENT+VLAN_VID_MAX)
                 return ofp_mkerr(OFPET_BAD_MATCH, OFPBMC_BAD_VALUE);
-            else
+            else 
                 ofl_structs_match_put16m(match, f->header, ntohs(*vlan_id), ntohs(*vlan_mask));
             return 0;
         }

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -1201,10 +1201,17 @@ parse_match(char *str, struct ofl_match_header **match) {
         /* VLAN */
         if (strncmp(token, MATCH_DL_VLAN KEY_VAL, strlen(MATCH_DL_VLAN KEY_VAL)) == 0) {
             uint16_t dl_vlan;
-            if (parse_vlan_vid(token + strlen(MATCH_DL_VLAN KEY_VAL), &dl_vlan)) {
-                ofp_fatal(0, "Error parsing vlan label: %s.", token);
-            }
-            else ofl_structs_match_put16(m,OXM_OF_VLAN_VID, dl_vlan);
+            char *str = token + strlen(MATCH_DL_VLAN KEY_VAL);
+
+			if (strcmp(str, "any") == 0)
+				ofl_structs_match_put16m(m,OXM_OF_VLAN_VID_W, OFPVID_PRESENT, OFPVID_PRESENT);
+			else if (strcmp(str, "none") == 0)
+				ofl_structs_match_put16(m,OXM_OF_VLAN_VID, OFPVID_NONE);
+			else if (parse16(str, NULL, 0, 0xfff, &dl_vlan))
+				ofp_fatal(0, "Error parsing vlan label: %s.", token);
+			else
+				ofl_structs_match_put16(m,OXM_OF_VLAN_VID, dl_vlan | OFPVID_PRESENT);
+
             continue;
         }
         if (strncmp(token, MATCH_DL_VLAN_PCP KEY_VAL, strlen(MATCH_DL_VLAN_PCP KEY_VAL)) == 0) {


### PR DESCRIPTION
Masking is not fully supported for vlan_vid (options are: "any", "none" or some number between 0 to 0xfff). 
