### PR TITLE
udatapath: use C++ linker

### DIFF
--- a/udatapath/automake.mk
+++ b/udatapath/automake.mk
@@ -46,6 +46,7 @@ udatapath_ofdatapath_SOURCES = \
 
 udatapath_ofdatapath_LDADD = lib/libopenflow.a oflib/liboflib.a oflib-exp/liboflib_exp.a nbee_link/libnbee_link.a $(SSL_LIBS) $(FAULT_LIBS)
 udatapath_ofdatapath_CPPFLAGS = $(AM_CPPFLAGS)
+nodist_EXTRA_udatapath_ofdatapath_SOURCES = dummy.cxx
 
 EXTRA_DIST += udatapath/ofdatapath.8.in
 DISTCLEANFILES += udatapath/ofdatapath.8


### PR DESCRIPTION
The nbee library is written in C++ so we have to use the C++ linker. Normally
automake detects which linker to use from the source file extensions, but
all of our sources are C. The trick suggested in the [automake documentation](http://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html)
is to add a fake C++ source file which doesn't actually need to exist.

Fixes #24.
