### PR TITLE
128: Hex metadata is being displayed in decimal in flow statistics

### DIFF
--- a/oflib/ofl-structs-print.c
+++ b/oflib/ofl-structs-print.c
@@ -398,9 +398,9 @@ ofl_structs_oxm_tlv_print(FILE *stream, struct ofl_match_tlv *f)
 			fprintf(stream, "mpls_bos=\"%d\"", *f->value & 0x1);
 			break;
 		case OFPXMT_OFB_METADATA:
-			fprintf(stream, "metadata=\"0x%"PRIu64"\"", *((uint64_t*) f->value));
+			fprintf(stream, "metadata=\"0x%"PRIx64"\"", *((uint64_t*) f->value));
 			if (OXM_HASMASK(f->header)) {
-				fprintf(stream, ", metadata_mask=\"0x%"PRIu64"\"", *((uint64_t*)(f->value+8)));
+				fprintf(stream, ", metadata_mask=\"0x%"PRIx64"\"", *((uint64_t*)(f->value+8)));
 			}
 			break;
 		case OFPXMT_OFB_PBB_ISID   :


### PR DESCRIPTION
Fixed the code to use hex format specifier. 

After fix:

> $ sudo dpctl unix:/tmp/s1 flow-mod cmd=add,table=5 in_port=2,meta=0xb 
> SENDING (xid=0xF0FF00F0):
> flow_mod{table="5", cmd="add", cookie="0x0", mask="0x0", idle="0", hard="0", prio="32768", buf="none", port="any", group="any", flags="0x0", match=oxm{in_port="2", metadata="0xb"}, insts=[]}
> 
> OK.
> 
> $ sudo dpctl unix:/tmp/s1 stats-flow | grep "{table=\"5\""
> stat_repl{type="flow", flags="0x0", stats=[{table="5", match="oxm{in_port="2", metadata="0xb"}", dur_s="6", dur_ns="672000", prio="32768", idle_to="0", hard_to="0", cookie="0x0", pkt_cnt="0", byte_cnt="0", insts=[]}]}
