### PR TITLE
Fix multipart duration nsec field.

### DIFF
--- a/udatapath/dp_ports.c
+++ b/udatapath/dp_ports.c
@@ -704,7 +704,7 @@ dp_ports_handle_port_mod(struct datapath *dp, struct ofl_msg_port_mod *msg,
 static void
 dp_port_stats_update(struct sw_port *port) {
     port->stats->duration_sec  =  (time_msec() - port->created) / 1000;
-    port->stats->duration_nsec = ((time_msec() - port->created) % 1000) * 1000;
+    port->stats->duration_nsec = ((time_msec() - port->created) % 1000) * 1000000;
 }
 
 void
@@ -796,7 +796,7 @@ dp_ports_handle_port_desc_request(struct datapath *dp,
 static void
 dp_ports_queue_update(struct sw_queue *queue) {
     queue->stats->duration_sec  =  (time_msec() - queue->created) / 1000;
-    queue->stats->duration_nsec = ((time_msec() - queue->created) % 1000) * 1000;
+    queue->stats->duration_nsec = ((time_msec() - queue->created) % 1000) * 1000000;
 }
 
 ofl_err

--- a/udatapath/flow_entry.c
+++ b/udatapath/flow_entry.c
@@ -191,7 +191,7 @@ flow_entry_hard_timeout(struct flow_entry *entry) {
 void
 flow_entry_update(struct flow_entry *entry) {
     entry->stats->duration_sec  =  (time_msec() - entry->created) / 1000;
-    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000;
+    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000000;
 }
 
 /* Returns true if the flow entry has a reference to the given group. */

--- a/udatapath/group_entry.c
+++ b/udatapath/group_entry.c
@@ -317,7 +317,7 @@ group_entry_execute(struct group_entry *entry,
 void
 group_entry_update(struct group_entry *entry){
     entry->stats->duration_sec  =  (time_msec() - entry->created) / 1000;
-    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000;
+    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000000;
 }
 
 /* Returns true if the group entry has  reference to the flow entry. */

--- a/udatapath/meter_entry.c
+++ b/udatapath/meter_entry.c
@@ -142,7 +142,7 @@ meter_entry_create(struct datapath *dp, struct meter_table *table, struct ofl_ms
 void
 meter_entry_update(struct meter_entry *entry) {
     entry->stats->duration_sec  =  (time_msec() - entry->created) / 1000;
-    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000;
+    entry->stats->duration_nsec = ((time_msec() - entry->created) % 1000) * 1000000;
 }
 
 void


### PR DESCRIPTION
This commit fixes #146 when computing duration_nsec field from stats multipart messages. This field must carry the duration in nanoseconds beyond duration_sec, but it was computing the value value in microseconds.