### PR TITLE
Fix queue id check when looking up or adding new queues.

### DIFF
--- a/udatapath/dp_ports.c
+++ b/udatapath/dp_ports.c
@@ -555,7 +555,7 @@ dp_ports_lookup_queue(struct sw_port *p, uint32_t queue_id)
 {
     struct sw_queue *q;
 
-    if (queue_id <= p->max_queues) {
+    if (queue_id < p->max_queues) {
         q = &(p->queues[queue_id]);
 
         if (q->port != NULL) {
@@ -988,7 +988,7 @@ static int
 port_add_queue(struct sw_port *p, uint32_t queue_id,
                struct ofl_queue_prop_min_rate * mr)
 {
-    if (queue_id > p->max_queues) {
+    if (queue_id >= p->max_queues) {
         return EXFULL;
     }
 


### PR DESCRIPTION
This commit fixs a small bug when checking for valid queue id during add queue and queue lookup functions. 

Note that struct sw_queue queues[NETDEV_MAX_QUEUES]; inside struct sw_port has a fixed number of NETDEV_MAX_QUEUES queues, ranging from 0 to NETDEV_MAX_QUEUES - 1.