### PR TITLE
Fix missing set_field=tunn_id: option in dpctl.

### DIFF
--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -1877,6 +1877,19 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
         }
         return 0;
     }
+    /* Tunnel ID */
+    if (strncmp(token, MATCH_TUNNEL_ID KEY_VAL2, strlen(MATCH_TUNNEL_ID KEY_VAL2)) == 0) {
+        uint64_t *tunn_id = malloc(sizeof(uint64_t));
+        if (sscanf(token, MATCH_TUNNEL_ID KEY_VAL2 "0x%"SCNx64"", (tunn_id)) != 1) {
+            ofp_fatal(0, "Error parsing %s: %s.", MATCH_TUNNEL_ID, token);
+        }
+        else {
+            act->field = (struct ofl_match_tlv*) malloc(sizeof(struct ofl_match_tlv));
+            act->field->header = OXM_OF_TUNNEL_ID;
+            act->field->value = (uint8_t*) tunn_id;
+        }
+        return 0;
+    }
     ofp_fatal(0, "Error parsing set_field arg: %s.", token);
 }
 


### PR DESCRIPTION
This commit fixes the dpctl utility, including the option to set the tunnel id field on flow_mod commands. According to the OpenFlow specification 1.3.5, "The pipeline field OXM_OF_TUNNEL_ID is valid in the set-field action, other pipeline fields, OXM_OF_IN_PORT, OXM_OF_IN_PHY_PORT and OXM_OF_METADATA are not valid in the set-field action".
