### PR TITLE
This commit fix other mismatch on print format strings. 

### DIFF
--- a/oflib/ofl-messages-print.c
+++ b/oflib/ofl-messages-print.c
@@ -205,7 +205,7 @@ ofl_msg_print_meter_mod(struct ofl_msg_meter_mod *msg, FILE *stream) {
     fprintf(stream,"{cmd=\"");
     ofl_meter_mod_command_print(stream, msg->command);
     fprintf(stream, "\", flags=\"0x%"PRIx16"\"",msg->flags);
-    fprintf(stream, "\", meter_id=\"%"PRIx32"\"",msg->meter_id);
+    fprintf(stream, "\", meter_id=\"%"PRIu32"\"",msg->meter_id);
     fprintf(stream,"\", bands=[");
 
     for (i=0; i<msg->meter_bands_num; i++) {

--- a/oflib/ofl-structs-print.c
+++ b/oflib/ofl-structs-print.c
@@ -729,8 +729,8 @@ ofl_structs_meter_features_to_string(struct ofl_meter_features* s){
 void
 ofl_structs_meter_features_print(FILE *stream, struct ofl_meter_features* s){
     
-    fprintf(stream, "{max_meter=\"%"PRIu32"\", band_types=\"%"PRIx32"\","
-            "capabilities =\"%"PRIx32"\", max_bands = %u , max_color = %u",  
+    fprintf(stream, "{max_meter=\"%"PRIu32"\", band_types=\"0x%"PRIx32"\","
+            "capabilities =\"0x%"PRIx32"\", max_bands = %u , max_color = %u",  
                 s->max_meter, s->band_types, s->capabilities, s->max_bands, s->max_color);
     fprintf(stream, "}"); 
 


### PR DESCRIPTION
Some strings were indicating hex but the variable were being printed as decimal, and vice versa.