### PR TITLE
compiles with gcc 7.3.0

### DIFF
--- a/lib/backtrace.c
+++ b/lib/backtrace.c
@@ -116,7 +116,7 @@ backtrace_capture(struct backtrace *backtrace)
     size_t n;
 
     n = 0;
-    for (frame = __builtin_frame_address(1);
+    for (frame = __builtin_frame_address(0);
          frame != NULL && in_stack(frame) && frame[0] != NULL
              && n < BACKTRACE_MAX_FRAMES;
          frame = frame[0])

--- a/oflib/oxm-match.c
+++ b/oflib/oxm-match.c
@@ -67,16 +67,6 @@
 
 static struct vlog_rate_limit rl = VLOG_RATE_LIMIT_INIT(1, 5);
 
-/* Possible masks for TLV OXM_ETH_DST_W. */
-static const uint8_t eth_all_0s[ETH_ADDR_LEN]
-    = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-static const uint8_t eth_all_1s[ETH_ADDR_LEN]
-    = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-static const uint8_t eth_mcast_1[ETH_ADDR_LEN]
-    = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
-static const uint8_t eth_mcast_0[ETH_ADDR_LEN]
-    = {0xfe, 0xff, 0xff, 0xff, 0xff, 0xff};
-
 struct oxm_field all_fields[NUM_OXM_FIELDS] = {
 #define DEFINE_FIELD(HEADER, DL_TYPES, NW_PROTO, MASKABLE)     \
     { HMAP_NODE_NULL_INITIALIZER, OFI_OXM_##HEADER, OXM_##HEADER, \

--- a/secchan/ratelimit.c
+++ b/secchan/ratelimit.c
@@ -83,7 +83,7 @@ drop_packet(struct rate_limiter *rl)
 
     longest = &rl->queues[0];
     n_longest = 1;
-    for (q = &rl->queues[0]; q < &rl->queues[OFPP_MAX]; q++) {
+    for (q = &rl->queues[0]; q < &rl->queues[65535]; q++) {
         if (longest->n < q->n) {
             longest = q;
             n_longest = 1;


### PR DESCRIPTION
Fixes 2/3 errors when compiling with gcc 7.3.0; for instance

secchan/ratelimit.c: In function 'rate_limit_local_packet_cb':
secchan/ratelimit.c:86:34: error: array subscript is above array bounds [-Werror=array-bounds]
     for (q = &rl->queues[0]; q < &rl->queues[OFPP_MAX]; q++) {