### PR TITLE
Fix incorrect bitwise comparison when checking port configuration.

### DIFF
--- a/udatapath/dp_ports.c
+++ b/udatapath/dp_ports.c
@@ -215,7 +215,7 @@ static void
 process_buffer(struct datapath *dp, struct sw_port *p, struct ofpbuf *buffer) {
     struct packet *pkt;
 
-    if (p->conf->config & ((OFPPC_NO_RECV | OFPPC_PORT_DOWN) != 0)) {
+    if ((p->conf->config & (OFPPC_NO_RECV | OFPPC_PORT_DOWN)) != 0) {
         ofpbuf_delete(buffer);
         return;
     }


### PR DESCRIPTION
When building the switch with gcc 8 throws an error in dp_ports.c:218

> error: bitwise comparison always evaluates to true [-Werror=tautological-compare]
>    if (p->conf->config & ((OFPPC_NO_RECV | OFPPC_PORT_DOWN) != 0))
>                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
> cc1plus: all warnings being treated as errors

This is a bug, because it is checked whether the bitwise OR of the two flags is not equal to zero, which is always the case. The correct condition should be:

`if ((p->conf->config & (OFPPC_NO_RECV | OFPPC_PORT_DOWN)) != 0)`