### PR TITLE
Fix gcc 7.3 warning for -Wliteral-suffix

### DIFF
--- a/lib/packets.h
+++ b/lib/packets.h
@@ -104,7 +104,7 @@ static inline bool eth_addr_is_reserved(const uint8_t ea[ETH_ADDR_LEN])
 }
 
 #define ETH_ADDR_FMT                                                    \
-    "%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8
+    "%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
 #define ETH_ADDR_ARGS(ea)                                   \
     (ea)[0], (ea)[1], (ea)[2], (ea)[3], (ea)[4], (ea)[5]
 
@@ -198,7 +198,7 @@ BUILD_ASSERT_DECL(VLAN_ETH_HEADER_LEN == sizeof(struct vlan_eth_header));
  * argument of a comma expression, but it makes sure that 'ip' is a pointer.
  * This is useful since a common mistake is to pass an integer instead of a
  * pointer to IP_ARGS. */
-#define IP_FMT "%"PRIu8".%"PRIu8".%"PRIu8".%"PRIu8
+#define IP_FMT "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8
 #define IP_ARGS(ip)                             \
         ((void) (ip)[0], ((uint8_t *) ip)[0]),  \
         ((uint8_t *) ip)[1],                    \

--- a/nbee_link/nbee_link.cpp
+++ b/nbee_link/nbee_link.cpp
@@ -53,7 +53,7 @@ extern "C" int nblink_initialize(void)
     int NetPDLDecoderFlags = nbDECODER_GENERATEPDML;
     int ShowNetworkNames = 0;
 
-    char* NetPDLFileName = (char*) NETPDLDIR"/"NETPDLFILE;
+    char* NetPDLFileName = (char*) NETPDLDIR "/" NETPDLFILE;
     struct stat netpdlstat;
 
     struct sigaction sa;

--- a/oflib/ofl-actions-print.c
+++ b/oflib/ofl-actions-print.c
@@ -45,7 +45,7 @@
 
 
 #define ETH_ADDR_FMT                                                    \
-    "%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8
+    "%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
 #define ETH_ADDR_ARGS(ea)                                   \
     (ea)[0], (ea)[1], (ea)[2], (ea)[3], (ea)[4], (ea)[5]
 

--- a/oflib/ofl-structs-print.c
+++ b/oflib/ofl-structs-print.c
@@ -48,11 +48,11 @@
 
 
 #define ETH_ADDR_FMT                                                    \
-    "%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8
+    "%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
 #define ETH_ADDR_ARGS(ea)                                   \
     (ea)[0], (ea)[1], (ea)[2], (ea)[3], (ea)[4], (ea)[5]
 
-#define IP_FMT "%"PRIu8".%"PRIu8".%"PRIu8".%"PRIu8
+#define IP_FMT "%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8
 
 char *
 ofl_structs_port_to_string(struct ofl_port *port) {


### PR DESCRIPTION
This commit fixes the warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix] when compile the switch using gcc 7.3 on Ubuntu 18.04.