### PR TITLE
Parse masks in dpctl

### DIFF
--- a/udatapath/pipeline.c
+++ b/udatapath/pipeline.c
@@ -631,7 +631,7 @@ execute_entry(struct pipeline *pl, struct flow_entry *entry,
                     hmap_node, hash_int(OXM_OF_METADATA,0), &(*pkt)->handle_std->match.match_fields){
                     uint64_t *metadata = (uint64_t*) f->value;
                     *metadata = (*metadata & ~wi->metadata_mask) | (wi->metadata & wi->metadata_mask);
-                    VLOG_DBG_RL(LOG_MODULE, &rl, "Executing write metadata: %"PRIu64"", *metadata);
+                    VLOG_DBG_RL(LOG_MODULE, &rl, "Executing write metadata: 0x%"PRIx64"", *metadata);
                 }
                 break;
             }

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -1141,8 +1141,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put_eth(m,OXM_OF_ETH_SRC,eth_src);
-                else
+                else {
                     ofl_structs_match_put_eth_m(m,OXM_OF_ETH_SRC_W,eth_src,mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1155,8 +1157,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                  if (mask == NULL)
                     ofl_structs_match_put_eth(m,OXM_OF_ETH_DST,eth_dst);
-                 else
+                 else {
                     ofl_structs_match_put_eth_m(m,OXM_OF_ETH_DST_W,eth_dst, mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1170,8 +1174,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put_eth(m, OXM_OF_ARP_SHA, arp_sha);
-                else
+                else {
                     ofl_structs_match_put_eth_m(m, OXM_OF_ARP_SHA_W, arp_sha, mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1184,8 +1190,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put_eth(m,OXM_OF_ARP_THA, arp_tha);
-                else
+                else {
                     ofl_structs_match_put_eth_m(m,OXM_OF_ARP_THA_W, arp_tha, mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1198,8 +1206,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put32(m, OXM_OF_ARP_SPA,arp_src);
-                else
+                else {
                     ofl_structs_match_put32m(m, OXM_OF_ARP_SPA_W, arp_src, *mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1212,8 +1222,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put32(m, OXM_OF_ARP_TPA, arp_target);
-                else
+                else {
                     ofl_structs_match_put32m(m, OXM_OF_ARP_TPA_W, arp_target, *mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1299,8 +1311,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put32(m, OXM_OF_IPV4_SRC,nw_src);
-                else
+                else {
                     ofl_structs_match_put32m(m, OXM_OF_IPV4_SRC_W, nw_src, *mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1313,8 +1327,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 if (mask == NULL)
                     ofl_structs_match_put32(m, OXM_OF_IPV4_DST,nw_dst);
-                else
+                else {
                     ofl_structs_match_put32m(m, OXM_OF_IPV4_DST_W,nw_dst, *mask);
+                    free(mask);
+                }
             }
             continue;
         }
@@ -1461,8 +1477,10 @@ parse_match(char *str, struct ofl_match_header **match) {
             else
               if(mask == NULL)
                 ofl_structs_match_put32(m, OXM_OF_IPV6_FLABEL, ipv6_label);
-              else
+              else {
                 ofl_structs_match_put32m(m, OXM_OF_IPV6_FLABEL_W, ipv6_label, *mask);
+                free (mask);
+              }
             continue;
         }
 

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -2639,7 +2639,7 @@ parse8(char *str, struct names8 *names, size_t names_num, uint8_t max, uint8_t *
 
     /* Checks for value in hexadecimal. */
     if (str[0] == '0' && str[1] == 'x') {
-        if ((max > 0) && (sscanf(str, "%"SCNx8"", val)) == 1 && (*val <= max)) {
+        if ((max > 0) && (sscanf(str, "0x%"SCNx8"", val)) == 1 && (*val <= max)) {
             return 0;
         }
     } else {
@@ -2663,7 +2663,7 @@ parse16(char *str, struct names16 *names, size_t names_num, uint16_t max, uint16
 
     /* Checks for value in hexadecimal. */
     if (str[0] == '0' && str[1] == 'x') {
-        if ((max > 0) && (sscanf(str, "%"SCNx16"", val)) == 1 && (*val <= max)) {
+        if ((max > 0) && (sscanf(str, "0x%"SCNx16"", val)) == 1 && (*val <= max)) {
             return 0;
         }
     } else {
@@ -2690,7 +2690,7 @@ parse16m(char *str, struct names16 *names, size_t names_num, uint16_t max, uint1
 
     /* Checks for value in hexadecimal. */
     if (str[0] == '0' && str[1] == 'x') {
-        read = sscanf(str, "%"SCNx16"", val);
+        read = sscanf(str, "0x%"SCNx16"", val);
     } else {
         read = sscanf(str, "%"SCNu16"", val);
     }   
@@ -2707,7 +2707,7 @@ parse16m(char *str, struct names16 *names, size_t names_num, uint16_t max, uint1
 
     /* Checks for mask in hexadecimal. */
     if (saveptr[0] == '0' && saveptr[1] == 'x') {
-        read = sscanf(saveptr, "%"SCNx16"", *mask);
+        read = sscanf(saveptr, "0x%"SCNx16"", *mask);
     } else {
         read = sscanf(saveptr, "%"SCNu16"", *mask);
     }
@@ -2731,7 +2731,7 @@ parse32(char *str, struct names32 *names, size_t names_num, uint32_t max, uint32
 
     /* Checks for value in hexadecimal. */
     if (str[0] == '0' && str[1] == 'x') {
-        if ((max > 0) && (sscanf(str, "%"SCNx32"", val)) == 1 && (*val <= max)) {
+        if ((max > 0) && (sscanf(str, "0x%"SCNx32"", val)) == 1 && (*val <= max)) {
             return 0;
         }
     } else {
@@ -2758,7 +2758,7 @@ parse32m(char *str, struct names32 *names, size_t names_num, uint32_t max, uint3
 
     /* Checks for value in hexadecimal. */
     if (str[0] == '0' && str[1] == 'x') {
-        read = sscanf(str, "%"SCNx32"", val);
+        read = sscanf(str, "0x%"SCNx32"", val);
     } else {
         read = sscanf(str, "%"SCNu32"", val);
     }   
@@ -2775,7 +2775,7 @@ parse32m(char *str, struct names32 *names, size_t names_num, uint32_t max, uint3
 
     /* Checks for mask in hexadecimal. */
     if (saveptr[0] == '0' && saveptr[1] == 'x') {
-        read = sscanf(saveptr, "%"SCNx32"", *mask);
+        read = sscanf(saveptr, "0x%"SCNx32"", *mask);
     } else {
         read = sscanf(saveptr, "%"SCNu32"", *mask);
     }

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -2121,11 +2121,11 @@ parse_inst(char *str, struct ofl_instruction_header **inst) {
                     char *token, *saveptr = NULL;
                     struct ofl_instruction_write_metadata *i = xmalloc(sizeof(struct ofl_instruction_write_metadata));
                     i->header.type = OFPIT_WRITE_METADATA;
-                    token = strtok_r(s, KEY_SEP, &saveptr);
+                    token = strtok_r(s, MASK_SEP, &saveptr);
                     if (sscanf(token, "0x%"SCNx64"", &(i->metadata)) != 1) {
                         ofp_fatal(0, "Error parsing metadata in write metadata instruction: %s.", s);
                     }
-                    token = strtok_r(NULL, KEY_SEP, &saveptr);
+                    token = strtok_r(NULL, MASK_SEP, &saveptr);
                     if (token == NULL) {
                         i->metadata_mask = 0xffffffffffffffffULL;
                     } else {

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -2118,19 +2118,17 @@ parse_inst(char *str, struct ofl_instruction_header **inst) {
                     return;
                 }
                 case (OFPIT_WRITE_METADATA): {
-                    char *token, *saveptr = NULL;
+                    uint64_t *mask;
                     struct ofl_instruction_write_metadata *i = xmalloc(sizeof(struct ofl_instruction_write_metadata));
                     i->header.type = OFPIT_WRITE_METADATA;
-                    token = strtok_r(s, MASK_SEP, &saveptr);
-                    if (sscanf(token, "0x%"SCNx64"", &(i->metadata)) != 1) {
+                    if (parse64m(s, 0xffffffffffffffffULL, &(i->metadata), &mask)) {
                         ofp_fatal(0, "Error parsing metadata in write metadata instruction: %s.", s);
-                    }
-                    token = strtok_r(NULL, MASK_SEP, &saveptr);
-                    if (token == NULL) {
-                        i->metadata_mask = 0xffffffffffffffffULL;
                     } else {
-                        if (sscanf(token, "0x%"SCNx64"", &(i->metadata_mask)) != 1) {
-                            ofp_fatal(0, "Error parsing metadata_mask in write metadata instruction: %s.", s);
+                        if (mask == NULL) {
+                            i->metadata_mask = 0xffffffffffffffffULL;
+                        } else {
+                            i->metadata_mask = *mask;
+                            free (mask);
                         }
                     }
                     (*inst) = (struct ofl_instruction_header *)i;

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -1530,6 +1530,7 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                  ofl_structs_match_put_eth(m,OXM_OF_IPV6_ND_SLL, eth_src);
             }
+            if (mask != NULL) free(mask);
             continue;
         }
         if (strncmp(token, MATCH_IPV6_ND_TLL KEY_VAL, strlen(MATCH_IPV6_ND_TLL KEY_VAL)) == 0) {
@@ -1541,6 +1542,7 @@ parse_match(char *str, struct ofl_match_header **match) {
             else {
                 ofl_structs_match_put_eth(m, OXM_OF_IPV6_ND_TLL,eth_dst);
             }
+            if (mask != NULL) free(mask);
             continue;
         }
 
@@ -1614,6 +1616,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
                 act->field->header = OXM_OF_ETH_SRC;
                 act->field->value = (uint8_t*) dl_src;
             }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_DL_DST KEY_VAL2, strlen(MATCH_DL_DST KEY_VAL2)) == 0) {
@@ -1626,6 +1629,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
                 act->field->header = OXM_OF_ETH_DST;
                 act->field->value = (uint8_t*) dl_dst;
             }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_DL_TYPE KEY_VAL2, strlen(MATCH_DL_TYPE KEY_VAL2)) == 0) {
@@ -1653,6 +1657,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_ARP_SHA;
             act->field->value = (uint8_t*) arp_sha;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_ARP_THA KEY_VAL2, strlen(MATCH_ARP_THA KEY_VAL2)) == 0) {
@@ -1666,6 +1671,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_ARP_THA;
             act->field->value = (uint8_t*) arp_tha;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_ARP_SPA KEY_VAL2, strlen(MATCH_ARP_SPA KEY_VAL2)) == 0) {
@@ -1679,6 +1685,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_ARP_SPA;
             act->field->value = (uint8_t*) arp_src;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_ARP_TPA KEY_VAL2, strlen(MATCH_ARP_TPA KEY_VAL2)) == 0) {
@@ -1692,6 +1699,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_ARP_TPA;
             act->field->value = (uint8_t*) arp_target;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_ARP_OP KEY_VAL2, strlen(MATCH_ARP_OP KEY_VAL2)) == 0) {
@@ -1802,6 +1810,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_IPV4_SRC;
             act->field->value =  (uint8_t*) nw_src;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_NW_DST KEY_VAL2, strlen(MATCH_NW_DST KEY_VAL2)) == 0) {
@@ -1816,6 +1825,7 @@ parse_set_field(char *token, struct ofl_action_set_field *act) {
             act->field->header = OXM_OF_IPV4_DST;
             act->field->value =  (uint8_t*) nw_dst;
         }
+        if (mask != NULL) free(mask);
         return 0;
     }
     if (strncmp(token, MATCH_IP_ECN KEY_VAL2, strlen(MATCH_NW_DST KEY_VAL2)) == 0) {
@@ -2481,6 +2491,7 @@ parse_port_mod(char *str, struct ofl_msg_port_mod *msg) {
             if (parse_dl_addr(token + strlen(PORT_MOD_HW_ADDR KEY_VAL), msg->hw_addr, &mask)) {
                 ofp_fatal(0, "Error parsing port_mod hw_addr: %s.", token);
             }
+            if (mask != NULL) free(mask);
             continue;
         }
         if (strncmp(token, PORT_MOD_HW_CONFIG KEY_VAL, strlen(PORT_MOD_HW_CONFIG KEY_VAL)) == 0) {

--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -2619,8 +2619,15 @@ parse8(char *str, struct names8 *names, size_t names_num, uint8_t max, uint8_t *
         }
     }
 
-    if ((max > 0) && (sscanf(str, "%"SCNu8"", val)) == 1 && ((*val) <= max)) {
-        return 0;
+    /* Checks for value in hexadecimal. */
+    if (str[0] == '0' && str[1] == 'x') {
+        if ((max > 0) && (sscanf(str, "%"SCNx8"", val)) == 1 && (*val <= max)) {
+            return 0;
+        }
+    } else {
+        if ((max > 0) && (sscanf(str, "%"SCNu8"", val)) == 1 && (*val <= max)) {
+            return 0;
+        }
     }
     return -1;
 }
@@ -2636,16 +2643,15 @@ parse16(char *str, struct names16 *names, size_t names_num, uint16_t max, uint16
         }
     }
 
-    /* Checks if the passed value is hexadecimal. */
-    if( str[1] == 'x'){
-        if ((max > 0) && (sscanf(str, "%"SCNx16"", val))  == 1 && (*val <= max)) {
+    /* Checks for value in hexadecimal. */
+    if (str[0] == '0' && str[1] == 'x') {
+        if ((max > 0) && (sscanf(str, "%"SCNx16"", val)) == 1 && (*val <= max)) {
             return 0;
         }
-    }
-    else {
-         if ((max > 0) && (sscanf(str, "%"SCNu16"", val))  == 1 && (*val <= max)) {
+    } else {
+        if ((max > 0) && (sscanf(str, "%"SCNu16"", val)) == 1 && (*val <= max)) {
             return 0;
-         }
+        }
     }
     return -1;
 }
@@ -2689,8 +2695,15 @@ parse32(char *str, struct names32 *names, size_t names_num, uint32_t max, uint32
         }
     }
 
-    if ((max > 0) && (sscanf(str, "%"SCNu32"", val)) == 1 && ((*val) <= max)) {
-        return 0;
+    /* Checks for value in hexadecimal. */
+    if (str[0] == '0' && str[1] == 'x') {
+        if ((max > 0) && (sscanf(str, "%"SCNx32"", val)) == 1 && (*val <= max)) {
+            return 0;
+        }
+    } else {
+        if ((max > 0) && (sscanf(str, "%"SCNu32"", val)) == 1 && (*val <= max)) {
+            return 0;
+        }
     }
     return -1;
 }


### PR DESCRIPTION
This set of commits improves the dpctl utility for parsing masks on the following match fields: _ipv6_flabel, meta, and tunn_id_. The idea is to use the same syntax for masks on IP and MAC addresses, by using the "/" and the mask value just after the field value (instead of using a separated token as in the case of cookie and cookie_mask (discussions on changing this are welcome). Moreover, all integer parse methods were improved so they can handle values in decimal and hexadecimal values. It is also possible to mix one value in decimal and the other in hexadecimal. 

Usage examples: for matching tunnel ID 15 with mask 255 the user can write: _tunn_id=15/255_ or _tunn_id=0xF/0xFF_ 

**Important note**:
The write metadata instruction syntax was slightly changed to keep consistence. Previously, the comma char "," was used to separate the value and the mask, but commits 59ffc49 and 33ab0ae changed this to the default slash character. So now, as an example, users should type _meta:0xFF/0xFF_ for writing FF value with FF mask on the metadata field.