### PR TITLE
Meter Stats Bug Fix After Sending Meter Modify

### DIFF
--- a/udatapath/meter_table.c
+++ b/udatapath/meter_table.c
@@ -162,10 +162,20 @@ meter_table_modify(struct meter_table *table, struct ofl_msg_meter_mod *mod) {
     /* keep flow references from old meter entry */
     list_replace(&new_entry->flow_refs, &entry->flow_refs);
     list_init(&entry->flow_refs);
+    copy_stat_entries(&entry->stats, &new_entry->stats);
 
     meter_entry_destroy(entry);
     ofl_msg_free_meter_mod(mod, false);
     return 0;
+}
+
+void
+copy_stat_entries(struct ofl_meter_stats *stats, struct ofl_meter_stats *new_stats){
+    new_entry->flow_count = entry->flow_count;
+    new_entry->packet_in_count = entry->packet_in_count;
+    new_entry->byte_in_count = entry->byte_in_count;
+    new_entry->duration_sec = entry->duration_sec;
+    new_entry->duration_nsec = entry->duration_nsec;
 }
 
 /* Handles meter_mod messages with DELETE command. */


### PR DESCRIPTION
When we send Meter_Mod (Modify), then flow_count value of the meter stats is 0. However, we want to keep the oldest flow_count value. 

Example For The Bug:
Meter_Mod (ADD)
Meter_Stat_Reply -> flow_count : 1
Meter_Mod (MODIFY)
Meter_Stat_Reply -> flow_count: 0

In order to solve this issue, I set the oldest flow count value to the new meter entry.
BR,