### PR TITLE
Fix compilation warnings for gcc -O0 flag.

### DIFF
--- a/lib/netdev.c
+++ b/lib/netdev.c
@@ -1071,7 +1071,7 @@ netdev_recv(struct netdev *netdev, struct ofpbuf *buffer, size_t max_mtu)
                 }
                 /* VLAN tag found. Shift MAC addresses down and insert VLAN tag */
                 /* Create headroom for the VLAN tag */
-                eth_type = ntohs(*((uint16_t *)(buffer->data + ETHER_ADDR_LEN * 2)));                
+                eth_type = ntohs(*((uint16_t *)((uint8_t*)buffer->data + ETHER_ADDR_LEN * 2)));                
                 ofpbuf_push_uninit(buffer, VLAN_HEADER_LEN);
                 memmove(buffer->data, (uint8_t*)buffer->data+VLAN_HEADER_LEN, ETH_ALEN * 2);
                 tag = (struct vlan_tag *)((uint8_t*)buffer->data + ETH_ALEN * 2);

--- a/oflib/ofl-actions-unpack.c
+++ b/oflib/ofl-actions-unpack.c
@@ -346,7 +346,7 @@ ofl_actions_unpack(struct ofp_action_header *src, size_t *len, struct ofl_action
             return ofl_error(OFPET_BAD_ACTION, OFPBAC_BAD_TYPE);
         }
     }
-    (*dst)->type = (enum ofp_action_type)ntohs(src->type);
+    (*dst)->type = (enum ofp_action_type)((int)ntohs(src->type));
 
     return 0;
 }

--- a/oflib/ofl-messages-unpack.c
+++ b/oflib/ofl-messages-unpack.c
@@ -66,7 +66,7 @@ ofl_msg_unpack_error(struct ofp_header *src, size_t *len, struct ofl_msg_header 
 
     de = (struct ofl_msg_error *)malloc(sizeof(struct ofl_msg_error));
 
-    de->type = (enum ofp_error_type)ntohs(se->type);
+    de->type = (enum ofp_error_type)((int)ntohs(se->type));
     de->code = ntohs(se->code);
     de->data_length = *len;
     de->data = *len > 0 ? (uint8_t *)memcpy(malloc(*len), se->data, *len) : NULL;
@@ -539,7 +539,7 @@ ofl_msg_unpack_group_mod(struct ofp_header *src, size_t *len, struct ofl_msg_hea
 
     dm = (struct ofl_msg_group_mod *)malloc(sizeof(struct ofl_msg_group_mod));
 
-    dm->command = (enum ofp_group_mod_command)ntohs(sm->command);
+    dm->command = (enum ofp_group_mod_command)((int)ntohs(sm->command));
     dm->type = sm->type;
     dm->group_id = ntohl(sm->group_id);
 
@@ -983,7 +983,7 @@ ofl_msg_unpack_multipart_request(struct ofp_header *src,uint8_t *buf, size_t *le
     }
 
     ofls = (struct ofl_msg_multipart_request_header *)(*msg);
-    ofls->type = (enum ofp_multipart_types)ntohs(os->type);
+    ofls->type = (enum ofp_multipart_types)((int)ntohs(os->type));
     ofls->flags = ntohs(os->flags);
 
     return 0;
@@ -1523,7 +1523,7 @@ ofl_msg_unpack_multipart_reply(struct ofp_header *src, uint8_t *buf, size_t *len
     }
 
     ofls = (struct ofl_msg_multipart_reply_header *)(*msg);
-    ofls->type = (enum ofp_multipart_types)ntohs(os->type);
+    ofls->type = (enum ofp_multipart_types)((int)ntohs(os->type));
     ofls->flags = ntohs(os->flags);
 
     return 0;

--- a/oflib/ofl-structs-unpack.c
+++ b/oflib/ofl-structs-unpack.c
@@ -157,7 +157,7 @@ ofl_structs_instructions_unpack(struct ofp_instruction *src, size_t *len, struct
             }
 
             inst = (struct ofl_instruction_header *)malloc(sizeof(struct ofl_instruction_header));
-            inst->type = (enum ofp_instruction_type)ntohs(src->type);
+            inst->type = (enum ofp_instruction_type)((int)ntohs(src->type));
 
             ilen -= sizeof(struct ofp_instruction_actions);
             break;
@@ -198,7 +198,7 @@ ofl_structs_instructions_unpack(struct ofp_instruction *src, size_t *len, struct
     }
 
     // must set type before check, so free works correctly
-    inst->type = (enum ofp_instruction_type)ntohs(src->type);
+    inst->type = (enum ofp_instruction_type)((int)ntohs(src->type));
 
     if (ilen != 0) {
         *len = *len - ntohs(src->len) + ilen;
@@ -346,7 +346,7 @@ ofl_structs_table_properties_unpack(struct ofp_table_feature_prop_header * src, 
 	}
 
     // must set type before check, so free works correctly
-    prop->type = (enum ofp_table_feature_prop_type) ntohs(src->type);
+    prop->type = (enum ofp_table_feature_prop_type)((int)ntohs(src->type));
     /* Make sure it can be reused for packing. Jean II */
     prop->length = ntohs(src->length);
 
@@ -831,7 +831,7 @@ ofl_structs_queue_prop_unpack(struct ofp_queue_prop_header *src, size_t *len, st
         }
     }
 
-    (*dst)->type = (enum ofp_queue_properties)ntohs(src->property);
+    (*dst)->type = (enum ofp_queue_properties)((int)ntohs(src->property));
     return 0;
 }
 


### PR DESCRIPTION
This commit fixes some errors when configuring and compiling the switch without gcc optmization flags (./configure CFLAGS='-g -O2' CXXFLAGS='-g -O2').