### PR TITLE
Fix wrong flow-mod parser for strings with only match or instructions.

### DIFF
--- a/utilities/dpctl.c
+++ b/utilities/dpctl.c
@@ -639,7 +639,7 @@ flow_mod(struct vconn *vconn, int argc, char *argv[]) {
                 If the match is empty, the argv is modified
                 causing errors to instructions parsing*/
                 char *cpy = malloc(strlen(argv[1])+1);
-                memcpy(cpy, argv[1], strlen(argv[1])); 
+                memcpy(cpy, argv[1], strlen(argv[1]) + 1); 
                 parse_match(cpy, &(msg.match));
                 free(cpy);
                 if(msg.match->length <= 4){


### PR DESCRIPTION
When parsing these flow-mod strings (argc == 2), the memcpy is being used to copy the string. However, the memcpy was configured with a wrong number of bytes to copy, skipping the last null string char. This was leading to random error depending on the memory garbage content.