### PR TITLE
strncpy and snprintf overflow fix. 

### DIFF
--- a/lib/netdev.c
+++ b/lib/netdev.c
@@ -1453,7 +1453,7 @@ netdev_arp_lookup(const struct netdev *netdev,
     pa->sin_port = 0;
     r.arp_ha.sa_family = ARPHRD_ETHER;
     r.arp_flags = 0;
-    strncpy(r.arp_dev, netdev->name, sizeof r.arp_dev);
+    strncpy(r.arp_dev, netdev->name, sizeof r.arp_dev -1);
     retval = ioctl(af_inet_sock, SIOCGARP, &r) < 0 ? errno : 0;
     if (!retval) {
         memcpy(mac, r.arp_ha.sa_data, ETH_ADDR_LEN);

--- a/oflib-exp/ofl-exp-openflow.c
+++ b/oflib-exp/ofl-exp-openflow.c
@@ -75,7 +75,7 @@ ofl_exp_openflow_msg_pack(struct ofl_msg_experimenter *msg, uint8_t **buf, size_
                 ofp->header.vendor  = htonl(exp->header.experimenter_id);
                 ofp->header.subtype = htonl(exp->type);
                 //We need a a byte less on DESC_STR_LEN
-                memset(ofp->dp_desc, 0, DESC_STR_LEN)
+                memset(ofp->dp_desc, 0, DESC_STR_LEN);
                 strncpy(ofp->dp_desc, s->dp_desc, DESC_STR_LEN-1);
 
                 return 0;

--- a/oflib-exp/ofl-exp-openflow.c
+++ b/oflib-exp/ofl-exp-openflow.c
@@ -74,7 +74,9 @@ ofl_exp_openflow_msg_pack(struct ofl_msg_experimenter *msg, uint8_t **buf, size_
                 ofp = (struct openflow_ext_set_dp_desc *)(*buf);
                 ofp->header.vendor  = htonl(exp->header.experimenter_id);
                 ofp->header.subtype = htonl(exp->type);
-                strncpy(ofp->dp_desc, s->dp_desc, DESC_STR_LEN);
+                //We need a a byte less on DESC_STR_LEN
+                memset(ofp->dp_desc, 0, DESC_STR_LEN)
+                strncpy(ofp->dp_desc, s->dp_desc, DESC_STR_LEN-1);
 
                 return 0;
             }

--- a/oflib/ofl-structs-pack.c
+++ b/oflib/ofl-structs-pack.c
@@ -440,7 +440,8 @@ ofl_structs_table_features_pack(struct ofl_table_features *src, struct ofp_table
     total_len = sizeof(struct ofp_table_features) + ofl_structs_table_features_properties_ofp_total_len(src->properties,src->properties_num,exp);
     dst->table_id = src->table_id;
     memset(dst->pad, 0x0,5);
-    strncpy(dst->name,src->name, OFP_MAX_TABLE_NAME_LEN);
+    memset(dst->name, 0x0,OFP_MAX_TABLE_NAME_LEN);
+    strncpy(dst->name,src->name, OFP_MAX_TABLE_NAME_LEN-1);
     dst->metadata_match = hton64(src->metadata_match);
     dst->metadata_write = hton64(src->metadata_write);
     dst->config = htonl(src->config);
@@ -835,7 +836,8 @@ ofl_structs_port_pack(struct ofl_port *src, struct ofp_port *dst) {
     memset(dst->pad, 0x00, 4);
     memcpy(dst->hw_addr, src->hw_addr, ETH_ADDR_LEN);
     memset(dst->pad2, 0x00, 2);
-    strncpy(dst->name, src->name, OFP_MAX_PORT_NAME_LEN);
+    memset(dst->name, 0x00, OFP_MAX_PORT_NAME_LEN);
+    strncpy(dst->name, src->name, OFP_MAX_PORT_NAME_LEN-1);
     dst->config     = htonl(src->config);
     dst->state      = htonl(src->state);
     dst->curr       = htonl(src->curr);

--- a/udatapath/datapath.c
+++ b/udatapath/datapath.c
@@ -158,7 +158,9 @@ dp_new(void) {
 
     if(strlen(dp->dp_desc) == 0) {
         /* just use "$HOSTNAME pid=$$" */
-        char hostnametmp[DESC_STR_LEN];
+        // We need to adjust for it to fit dp 
+        size_t prefix_len = strlen(" pid=") + 10;
+        char hostnametmp[DESC_STR_LEN-prefix_len-1];
         char pid[10];
         gethostname(hostnametmp,sizeof hostnametmp);
         sprintf(pid, "%u", getpid());

--- a/udatapath/datapath.c
+++ b/udatapath/datapath.c
@@ -162,7 +162,7 @@ dp_new(void) {
         char pid[10];
         gethostname(hostnametmp,sizeof hostnametmp);
         sprintf(pid, "%u", getpid());
-        snprintf(dp->dp_desc, strlen(hostnametmp) + 5 + strlen(pid),"%s pid=%s",hostnametmp, pid);
+        snprintf(dp->dp_desc, strlen(hostnametmp) + 6 + strlen(pid),"%s pid=%s",hostnametmp, pid);
     }
 
     /* FIXME: Should not depend on udatapath_as_lib */

--- a/udatapath/datapath.c
+++ b/udatapath/datapath.c
@@ -162,7 +162,7 @@ dp_new(void) {
         char pid[10];
         gethostname(hostnametmp,sizeof hostnametmp);
         sprintf(pid, "%u", getpid());
-        snprintf(dp->dp_desc, strlen(hostnametmp) + 6 + strlen(pid),"%s pid=%s",hostnametmp, pid);
+        snprintf(dp->dp_desc, DESC_STR_LEN-1,"%s pid=%s",hostnametmp, pid);
     }
 
     /* FIXME: Should not depend on udatapath_as_lib */


### PR DESCRIPTION
Current Makefile cannot compile due to [new GCC 8.0 warning](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82944). Edited files to not display warning instead of ignoring it. Also patched what seems to be an error on snprintf arguments. 